### PR TITLE
. Fix build pipeline correctness and update stale formulas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,11 @@ scripts/
   functions.sh              # Shared utilities: logging, version DB, var substitution
   environ.sh                # Default env vars (paths, arch, maintainer)
   pkg-common.sh             # build_package() — orchestrates one formula end-to-end
-  deb-builder.sh            # build_deb()
-  rpm-builder.sh            # build_rpm()
+  nfpm-builder.sh           # build_nfpm() — builds .deb and .rpm via nfpm (default)
+  deb-builder.sh            # build_deb() — legacy DEB builder (used when USE_NFPM=0)
+  rpm-builder.sh            # build_rpm() — legacy RPM builder (used when USE_NFPM=0)
   deb-updater.sh            # APT repo update
+  uploader_local.sh         # Local upload backend
   creator/
     formula_creator.sh      # Interactive AI-assisted formula generator
     system_prompt.md        # System prompt for the AI
@@ -33,8 +35,8 @@ formulas/
   *.sformula                # Inactive/draft formulas (ignored by runner.sh)
 versions.db                 # key=version pairs tracking last-built versions
 dist/
-  deb/                      # Built .deb files
-  rpm/x86_64/               # Built .rpm files
+  deb/                      # Built .deb files (accumulates across runs)
+  rpm/x86_64/               # Built .rpm files (accumulates across runs)
 .env                        # Runtime secrets and overrides (not committed)
 ```
 
@@ -162,7 +164,7 @@ PACKAGE_LICENSE="BSL-1.1"
 | `DOWNLOAD_URL_TEMPLATE` | Yes | Full download URL (supports variable substitution) |
 | `EXTRACT_CMD` | Yes* | `tar zxf`, `tar xf`, `tar jxf`, `unzip`, `gunzip`, `cp`, or `""` (no extraction) |
 | `INSTALL_FILES` | Yes | Array of `"src\|perms\|dest"` entries |
-| `CLEANUP_FILES` | Recommended | Space-separated files/dirs to remove after build |
+| `CLEANUP_FILES` | Recommended | Space-separated files/dirs to remove after build (relative to build folder, supports variable substitution) |
 | `PACKAGE_DESCRIPTION` | Yes | Full package description (multi-line ok) |
 | `PACKAGE_SUMMARY` | Yes | Single-line summary |
 | `PACKAGE_LICENSE` | Yes | SPDX identifier: `MIT`, `Apache-2.0`, `BSL-1.1`, etc. |
@@ -171,12 +173,12 @@ PACKAGE_LICENSE="BSL-1.1"
 
 ## Variable substitution
 
-These variables are available inside `DOWNLOAD_FILENAME`, `DOWNLOAD_URL_TEMPLATE`, and `INSTALL_FILES`. Use `\$VAR` (escaped) in the formula file so expansion happens at build time, not when the file is sourced.
+These variables are available inside `DOWNLOAD_FILENAME`, `DOWNLOAD_URL_TEMPLATE`, `INSTALL_FILES`, and `CLEANUP_FILES`. Use `\$VAR` (escaped) in the formula file so expansion happens at build time, not when the file is sourced.
 
 | Variable | Value | Example |
 |---|---|---|
-| `$LATEST_VER` | Full version tag from upstream | `v2.9.1` or `2.9.1` |
-| `$DPKG_VERSION` | Version without leading `v` or `r` | `2.9.1` |
+| `$LATEST_VER` | Full version tag from upstream | `v2.9.1`, `2.9.1`, `r41` |
+| `$DPKG_VERSION` | Version with any leading non-digit prefix stripped | `2.9.1`, `41` |
 | `$TARGET_ARCH` | CPU arch for filenames | `x86_64` |
 | `$DPKG_ARCH` | Debian arch string | `amd64` |
 | `$REPO` | GitHub repo path | `sharkdp/bat` |
@@ -184,7 +186,10 @@ These variables are available inside `DOWNLOAD_FILENAME`, `DOWNLOAD_URL_TEMPLATE
 | `$DOWNLOAD_FILENAME` | Resolved filename (after its own substitution) | `bat-2.9.1-x86_64-...tar.gz` |
 | `$HASHICORP_PRODUCT` | HashiCorp product name | `terraform` |
 
-**Rule:** If the upstream URL uses a bare version like `2.9.1` → use `$DPKG_VERSION`. If it uses `v2.9.1` → use `$LATEST_VER`.
+**Version prefix rule:**
+- If the upstream URL uses a bare version like `2.9.1` → use `$DPKG_VERSION`
+- If it uses `v2.9.1` → use `$LATEST_VER`
+- `$DPKG_VERSION` strips **any** leading non-digit characters (not just `v`): `r41` → `41`, `v1.0` → `1.0`
 
 ---
 
@@ -207,6 +212,24 @@ INSTALL_FILES=(
 
 ---
 
+## `CLEANUP_FILES` format
+
+Space-separated list of files and/or directories to delete after a successful build.
+Paths are **relative to the build folder** (the temp dir where extraction happened), not the project root.
+Variable substitution is applied to each entry before deletion.
+
+```bash
+# Delete the entire extracted directory
+CLEANUP_FILES="toolname-\$LATEST_VER-x86_64-unknown-linux-gnu"
+
+# Or list individual files
+CLEANUP_FILES="toolname LICENSE.txt README.md"
+```
+
+Cleanup only runs on success — if the build fails, the build folder is left intact for debugging.
+
+---
+
 ## `EXTRACT_CMD` notes
 
 | Value | When to use |
@@ -221,17 +244,27 @@ INSTALL_FILES=(
 
 ---
 
+## `dist/` package management
+
+`dist/deb/` and `dist/rpm/x86_64/` accumulate packages across builds — they are never wiped between runs. When a new version of a package is built successfully, the previous version for that package is automatically removed from `dist/`. If a build fails, the old version is preserved.
+
+This means the upload always has all packages (not just the latest batch), and the uploader can be run independently of a build.
+
+---
+
 ## How `runner.sh` processes a formula
 
-1. `source formula_file` — loads all variables into the current shell
-2. Detect `FORMULA_TYPE` (default: `github`)
-3. Call the appropriate version-fetch function → sets `$LATEST_VER`
-4. Compare with `versions.db` — skip if already up to date (unless `-f`)
-5. Run `var_substitution` on `DOWNLOAD_FILENAME` and `DOWNLOAD_URL_TEMPLATE`
-6. `wget` the file into a temp build folder
-7. Run `EXTRACT_CMD`
-8. Call `build_deb` and `build_rpm`
-9. Update `versions.db`
+1. Unset all formula variables (prevents leakage between formulas)
+2. `source formula_file` — loads all variables into the current shell
+3. Detect `FORMULA_TYPE` (default: `github`)
+4. Call the appropriate version-fetch function → sets `$LATEST_VER`
+5. Compute `$DPKG_VERSION` by stripping any leading non-digit prefix from `$LATEST_VER`
+6. Compare with `versions.db` — skip if already up to date (unless `-f`)
+7. Run `var_substitution` on `DOWNLOAD_FILENAME` and `DOWNLOAD_URL_TEMPLATE`
+8. `wget` the file into a temp build folder (`/tmp/pkgone-*/build/`)
+9. Run `EXTRACT_CMD`
+10. Call `build_nfpm` (or `build_deb` + `build_rpm` if `USE_NFPM=0`)
+11. On success: remove old versions from `dist/`, update `versions.db`
 
 ---
 
@@ -250,10 +283,11 @@ INSTALL_FILES=(
    ```
 4. Note which files you need: binary, man page, completions, license.
 5. Write the formula. Key decisions:
-   - Does the URL use `v2.1.0` or `2.1.0`? → choose `$LATEST_VER` or `$DPKG_VERSION`
+   - Does the URL use `v2.1.0` or `2.1.0`? → choose `\$LATEST_VER` or `\$DPKG_VERSION`
    - Does the archive extract to a subdirectory? → include the path in `INSTALL_FILES`
+   - Only include files that actually exist in the archive
 6. Save as `formulas/<toolname>-pkg.formula`
-7. Test: `bash runner.sh -b formulas/<toolname>-pkg.formula -f`
+7. Test: `bash runner.sh -b <toolname> -f`
 
 ### For a url_html tool
 
@@ -264,7 +298,7 @@ INSTALL_FILES=(
    curl -sL <page_url> | grep -oP '<your_regex>' | head -1
    ```
 4. Write the formula with `FORMULA_TYPE="url_html"`.
-5. Test with `bash runner.sh -b formulas/<toolname>-pkg.formula -f`.
+5. Test with `bash runner.sh -b <toolname> -f`.
 
 ### For a HashiCorp tool
 
@@ -272,7 +306,7 @@ INSTALL_FILES=(
    ```bash
    curl -s https://api.releases.hashicorp.com/v1/releases/<product>/latest | jq .version
    ```
-2. Verify the zip contents (they follow a standard pattern but some products differ):
+2. Verify the zip contents:
    ```bash
    VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/<product>/latest | jq -r .version)
    wget -q https://releases.hashicorp.com/<product>/$VERSION/<product>_${VERSION}_linux_amd64.zip -O /tmp/hc.zip
@@ -280,7 +314,7 @@ INSTALL_FILES=(
    ```
 3. Write the formula using the `hashicorp` template above, adjusting `INSTALL_FILES` based on the zip contents.
 4. Set the correct `HOMEPAGE` for the product.
-5. Test with `bash runner.sh -b formulas/<toolname>-pkg.formula -f`.
+5. Test with `bash runner.sh -b <toolname> -f`.
 
 ---
 
@@ -290,7 +324,9 @@ INSTALL_FILES=(
 |---|---|---|
 | Using `$LATEST_VER` when URL has no `v` prefix | Download 404 | Use `$DPKG_VERSION` instead |
 | Not escaping `$` in formula (`$VAR` instead of `\$VAR`) | Variable expands at source time with empty value | Escape: `\$LATEST_VER` |
-| Missing files in `CLEANUP_FILES` | Build artifacts left in temp folder | List every path from `INSTALL_FILES` |
+| Hardcoding a version number in `INSTALL_FILES` paths | Build fails when version changes | Use `\$LATEST_VER` or `\$DPKG_VERSION` |
+| Including files in `INSTALL_FILES` that don't exist in the archive | Build fails with "file does not exist" | Check archive contents with `tar tvf` or `unzip -l` first |
+| Using `dist` or another project-root name in `CLEANUP_FILES` | No longer an issue (cleanup now runs from build folder) | — |
 | `FORMULA_TYPE` but no `DPKG_BASENAME` | Build fails with validation error | Always set `DPKG_BASENAME` |
 | Literal product name in HashiCorp template | Wrong package if formula is reused | Use `\${HASHICORP_PRODUCT}` |
 | `url_html` with regex that doesn't match | Build fails with "could not extract version" | Validate regex with `curl + grep -oP` before saving |
@@ -331,14 +367,6 @@ grep '| [a-z]' README.md | awk -F'|' '{print $2}' | tr -d ' ' | sort
 
 Compare the two lists. Any name in the first list but not the second needs a new row.
 
-### How to determine the row values
-
-| Column | How to get it |
-|---|---|
-| Tool | `DPKG_BASENAME` from the formula |
-| Type | `FORMULA_TYPE` (or `github` if not set) |
-| Source | github: `REPO` value — url_html: domain + path of `VERSION_URL` — hashicorp: `releases.hashicorp.com` |
-
 ### Row format
 
 ```markdown
@@ -356,8 +384,9 @@ Rows are sorted alphabetically by tool name. Insert in the correct position.
 ```
 GITHUB_TOKEN=...           # Increases GitHub API rate limit (recommended)
 OPENROUTER_API_KEY=...     # Required for formula_creator.sh
-PKG1UPLOADER=local         # Upload backend: 'local' or 'buildkite'
+PKG1UPLOADER=local         # Upload backend
 PACKAGER_NAME=...
 PACKAGER_EMAIL=...
 VERBOSE=0
+USE_NFPM=1                 # Use nfpm for building (recommended, default)
 ```

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,80 @@
+# Uploader failure analysis — `runner.sh -u`
+
+## Symptom
+
+Running `bash runner.sh -u` manually fails with:
+
+```
+cp: cannot stat '/home/deese/devel/packagerone/dist/deb/*.deb': No such file or directory
+cp: cannot stat '/home/deese/devel/packagerone/dist/rpm/x86_64/*.rpm': No such file or directory
+```
+
+Works fine when launched automatically at the end of a full build run.
+
+## Root cause
+
+### 1. `dist/deb/` and `dist/rpm/x86_64/` are not pre-created
+
+`scripts/environ.sh` only creates `$OUTPUT_FOLDER` (`dist/`) and `logs/`. The subdirectories `dist/deb/` and `dist/rpm/` are created by `deb-builder.sh` / `nfpm-builder.sh` / `rpm-builder.sh` at build time. If no build has run, these directories don't exist.
+
+### 2. `mk-apt-repo.sh` and `mk-yum-repo.sh` fail hard on empty input
+
+Both scripts in `spzrepo/repo/` use `set -euo pipefail` and copy with an unguarded glob:
+
+```bash
+# mk-apt-repo.sh:27
+cp $INCOMING_DEB_FOLDER/*.deb "$APT_REPO_DIR/pool/main/"
+
+# mk-yum-repo.sh:17
+cp $INCOMING_RPM_FOLDER/*.rpm "$RPM_DIR/"
+```
+
+When the glob matches nothing (directory missing or empty), `cp` exits non-zero and `set -e` aborts the whole script.
+
+### 3. Why automatic run works
+
+Automatic upload is only triggered from `runner.sh` when `$CHANGES_FILE` is non-empty (i.e., at least one package was built successfully):
+
+```bash
+# runner.sh:116-118
+if [ -s $CHANGES_FILE ]; then
+    do_upload
+fi
+```
+
+At that point, `dist/deb/*.deb` and `dist/rpm/x86_64/*.rpm` exist. Manual `-u` skips the build entirely, so the dist folders may be absent.
+
+## Source of `INCOMING_DEB_FOLDER` / `INCOMING_RPM_FOLDER`
+
+Defined in `spzrepo/.env`:
+
+```
+INCOMING_DEB_FOLDER=/home/deese/devel/packagerone/dist/deb
+INCOMING_RPM_FOLDER=/home/deese/devel/packagerone/dist/rpm/x86_64
+```
+
+Loaded by `spzrepo/repo/functions.sh:read_env` inside both repo scripts.
+
+## Proposed fix
+
+In `spzrepo/repo/mk-apt-repo.sh`, before the `cp`:
+
+```bash
+if ! compgen -G "$INCOMING_DEB_FOLDER/*.deb" > /dev/null 2>&1; then
+    echo "No .deb files in $INCOMING_DEB_FOLDER — nothing to upload"
+    exit 0
+fi
+cp "$INCOMING_DEB_FOLDER"/*.deb "$APT_REPO_DIR/pool/main/"
+```
+
+In `spzrepo/repo/mk-yum-repo.sh`, before the `cp`:
+
+```bash
+if ! compgen -G "$INCOMING_RPM_FOLDER/*.rpm" > /dev/null 2>&1; then
+    echo "No .rpm files in $INCOMING_RPM_FOLDER — nothing to upload"
+    exit 0
+fi
+cp "$INCOMING_RPM_FOLDER"/*.rpm "$RPM_DIR/"
+```
+
+Both changes make the upload a no-op (exit 0) instead of a hard failure when there is nothing to upload.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,194 @@
+# PackageOne
+
+Automated builder for `.deb` and `.rpm` packages from upstream binary releases. No compilation — it downloads pre-built binaries, packages them, and optionally pushes them to a package repository.
+
+Each tool is described by a **formula file** (`formulas/*.formula`). Three source types are supported: GitHub releases, arbitrary URLs (with HTML version scraping), and HashiCorp's official release system.
+
+---
+
+## Requirements
+
+- `wget`, `curl`, `jq`
+- `nfpm` (DEB and RPM builds)
+- `unzip` (for `.zip` archives)
+- `bash` ≥ 4.0
+
+---
+
+## Setup
+
+Copy and fill in `.env`:
+
+```bash
+GITHUB_TOKEN=ghp_...           # Recommended — increases GitHub API rate limit
+OPENROUTER_API_KEY=sk-or-...   # Required only for the formula creator
+PKG1UPLOADER=local             # Upload backend
+PACKAGER_NAME=Your Name
+PACKAGER_EMAIL=you@example.com
+VERBOSE=0
+USE_NFPM=1
+```
+
+---
+
+## Usage
+
+```bash
+# Build all formulas
+bash runner.sh
+
+# Build a specific formula
+bash runner.sh -b bat
+
+# Force rebuild (ignore cached version)
+bash runner.sh -f
+
+# Check current vs latest versions without building
+bash runner.sh -V
+
+# Build only DEB packages (skip RPM)
+bash runner.sh -D
+
+# Build only RPM packages (skip DEB)
+bash runner.sh -R
+
+# Upload previously built packages
+bash runner.sh -u
+
+# Enable verbose output
+bash runner.sh -v
+```
+
+Flags can be combined: `bash runner.sh -f -D -v`
+
+Built packages are written to `dist/deb/` and `dist/rpm/x86_64/`.
+
+---
+
+## Formula types
+
+### GitHub releases (default)
+
+Fetches the latest release tag from the GitHub API and downloads the matching asset.
+
+```bash
+REPO="sharkdp/bat"
+DPKG_BASENAME="bat"
+DOWNLOAD_FILENAME="bat-\$LATEST_VER-x86_64-unknown-linux-gnu.tar.gz"
+DOWNLOAD_URL_TEMPLATE="https://github.com/\$REPO/releases/download/\$LATEST_VER/\$DOWNLOAD_FILENAME"
+EXTRACT_CMD="tar zxf"
+INSTALL_FILES=(
+    "bat-\$LATEST_VER-x86_64-unknown-linux-gnu/bat|755|/usr/bin/bat"
+)
+CLEANUP_FILES="bat-\$LATEST_VER-x86_64-unknown-linux-gnu"
+PACKAGE_DESCRIPTION="bat is a cat(1) clone with syntax highlighting and Git integration."
+PACKAGE_SUMMARY="cat clone with syntax highlighting"
+PACKAGE_LICENSE="MIT"
+```
+
+### URL / HTML scraping
+
+For tools distributed outside GitHub. The version is extracted from a web page using a PCRE regex.
+
+```bash
+FORMULA_TYPE="url_html"
+DPKG_BASENAME="ncdu"
+VERSION_URL="https://dev.yorhel.nl/ncdu"
+VERSION_REGEX='ncdu-\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-x86_64\.tar\.gz)'
+DOWNLOAD_FILENAME="ncdu-\$LATEST_VER-linux-x86_64.tar.gz"
+DOWNLOAD_URL_TEMPLATE="https://dev.yorhel.nl/download/\$DOWNLOAD_FILENAME"
+EXTRACT_CMD="tar zxf"
+INSTALL_FILES=(
+    "ncdu|755|/usr/bin/ncdu"
+)
+CLEANUP_FILES="ncdu"
+PACKAGE_DESCRIPTION="Disk usage analyzer with an ncurses text interface."
+PACKAGE_SUMMARY="Disk usage analyzer with ncurses text interface"
+PACKAGE_LICENSE="MIT"
+```
+
+### HashiCorp
+
+Uses `releases.hashicorp.com` and their JSON API for version detection.
+
+```bash
+FORMULA_TYPE="hashicorp"
+HASHICORP_PRODUCT="terraform"
+DPKG_BASENAME="terraform"
+HOMEPAGE="https://www.terraform.io"
+DOWNLOAD_FILENAME="\${HASHICORP_PRODUCT}_\${LATEST_VER}_linux_amd64.zip"
+DOWNLOAD_URL_TEMPLATE="https://releases.hashicorp.com/\${HASHICORP_PRODUCT}/\${LATEST_VER}/\${HASHICORP_PRODUCT}_\${LATEST_VER}_linux_amd64.zip"
+EXTRACT_CMD="unzip"
+INSTALL_FILES=(
+    "terraform|755|/usr/bin/terraform"
+    "LICENSE.txt|644|/usr/share/terraform/LICENSE.txt"
+)
+CLEANUP_FILES="terraform LICENSE.txt"
+PACKAGE_DESCRIPTION="Infrastructure as Code tool by HashiCorp."
+PACKAGE_SUMMARY="Infrastructure as Code tool by HashiCorp"
+PACKAGE_LICENSE="BSL-1.1"
+```
+
+---
+
+## Creating formulas
+
+### Automated (interactive, requires `OPENROUTER_API_KEY`)
+
+The creator script fetches release data, selects the best Linux binary, and generates a formula using an LLM. The result is shown for review before saving.
+
+```bash
+bash runner.sh -F sharkdp/bat                    # GitHub repo
+bash runner.sh -F hashicorp:vault                # HashiCorp product
+bash runner.sh -F https://dev.yorhel.nl/ncdu     # URL with HTML scraping
+```
+
+For `url_html` formulas the script also automatically derives and validates the `VERSION_REGEX` from the download link before passing it to the AI.
+
+### Manual
+
+1. Create `formulas/<toolname>-pkg.formula` with the appropriate fields.
+2. Test it: `bash runner.sh -b <toolname> -f`
+3. Check `dist/deb/` and `dist/rpm/x86_64/` for the output packages.
+
+---
+
+## Version tracking
+
+`versions.db` stores the last successfully built version per formula (one `key=version` per line). On each run, the stored version is compared to the upstream latest — formulas that are already up to date are skipped. Use `-f` to force a rebuild regardless.
+
+---
+
+## Currently packaged tools
+
+| Tool | Type | Source |
+|---|---|---|
+| atuin | github | atuinsh/atuin |
+| bat | github | sharkdp/bat |
+| btop | github | aristocratos/btop |
+| delta | github | dandavison/delta |
+| dua-cli | github | Byron/dua-cli |
+| duf | github | muesli/duf |
+| dust | github | bootandy/dust |
+| eza | github | eza-community/eza |
+| fd | github | sharkdp/fd |
+| fselect | github | jhspetersson/fselect |
+| fx | github | antonmedv/fx |
+| fzf | github | junegunn/fzf |
+| gdu | github | dundee/gdu |
+| gh | github | cli/cli |
+| gitleaks | github | gitleaks/gitleaks |
+| helix | github | helix-editor/helix |
+| hexyl | github | sharkdp/hexyl |
+| lf | github | gokcehan/lf |
+| ncdu | url_html | dev.yorhel.nl/ncdu |
+| neovim | github | neovim/neovim |
+| nfpm | github | goreleaser/nfpm |
+| packer | hashicorp | releases.hashicorp.com |
+| ripgrep | github | BurntSushi/ripgrep |
+| ssler | github | deese/ssler |
+| starship | github | starship-rs/starship |
+| tabiew | github | shshemi/tabiew |
+| terraform | hashicorp | releases.hashicorp.com |
+| uv | github | astral-sh/uv |
+| zoxide | github | ajeetdsouza/zoxide |


### PR DESCRIPTION
- Escape \$LATEST_VER in formula templates (both creator prompt and ssler) to prevent expansion at source time
- Unset LATEST_VER/DPKG_VERSION between formula builds to prevent leakage
- Strip any leading non-digit prefix from DPKG_VERSION (handles r41, v1.0, etc.)
- Run CLEANUP_FILES relative to BUILD_FOLDER instead of $PWD (was deleting dist/)
- Apply var_substitution to CLEANUP FILES entries
- nfpm RPM output now goes to dist/rpm/x86_64/ (consistent with rpmbuild)
- Old package versions removed from dist/ only after a successful build
- Fix delta/hexyl: replace hardcoded version in INSTALL_FILES with \$DPKG_VERSION/\$LATEST_VER
- Fix fd: remove fd.ps1 (not present in v10.4.2 archive)
- Fix duf: remove LICENSE/README.md (not in archive), add duf.1 man page
- Restore README.md and update AGENTS.md